### PR TITLE
Improvement: payment request data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ function PaymentExample() {
       const orderId = `order_${Date.now()}`;
 
       // Request payment
-      const response = await sdk.requestPayment(recipientAddress, {
+      const response = await sdk.requestPayment({
+        addressOrEns: recipientAddress,
         amount: 50,
         currency: FiatCurrency.USD,
         memo: orderId,

--- a/demo/js/app.js
+++ b/demo/js/app.js
@@ -99,7 +99,8 @@ async function requestPayment() {
       throw new Error('Amount must be a positive number');
     }
 
-    const paymentConfig = {
+    const paymentData = {
+      addressOrEns: address,
       amount,
       currency,
       memo: memo || undefined,
@@ -108,7 +109,7 @@ async function requestPayment() {
 
     log(`Requesting payment of ${amount} ${currency} to ${address}...`);
 
-    const response = await sdk.requestPayment(address, paymentConfig);
+    const response = await sdk.requestPayment(paymentData);
     log(
       `Payment successful! Transaction: ${response.txHash} on chain ${response.chainId}`,
       'success',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yodlpay/yapp-sdk",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "SDK for building Yodl Yapps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/MessageManager.test.ts
+++ b/src/__tests__/MessageManager.test.ts
@@ -229,7 +229,8 @@ describe('MessageManager', () => {
         );
 
         await expect(
-          manager.sendPaymentRequest(TEST_CONSTANTS.ADDRESS, {
+          manager.sendPaymentRequest({
+            addressOrEns: TEST_CONSTANTS.ADDRESS,
             amount: 100,
             currency: FiatCurrency.USD,
             memo: 'too-long-memo',
@@ -241,7 +242,8 @@ describe('MessageManager', () => {
         const manager = new MessageManager(TEST_CONSTANTS);
 
         await expect(
-          manager.sendPaymentRequest(TEST_CONSTANTS.ADDRESS, {
+          manager.sendPaymentRequest({
+            addressOrEns: TEST_CONSTANTS.ADDRESS,
             amount: 100,
             currency: 'INVALID' as FiatCurrency,
           }),
@@ -252,7 +254,8 @@ describe('MessageManager', () => {
         const manager = new MessageManager(TEST_CONSTANTS);
 
         await expect(
-          manager.sendPaymentRequest(TEST_CONSTANTS.ADDRESS, {
+          manager.sendPaymentRequest({
+            addressOrEns: TEST_CONSTANTS.ADDRESS,
             amount: -100,
             currency: FiatCurrency.USD,
           }),
@@ -263,7 +266,8 @@ describe('MessageManager', () => {
         const manager = new MessageManager(TEST_CONSTANTS);
 
         await expect(
-          manager.sendPaymentRequest(TEST_CONSTANTS.ADDRESS, {
+          manager.sendPaymentRequest({
+            addressOrEns: TEST_CONSTANTS.ADDRESS,
             amount: 0,
             currency: FiatCurrency.USD,
           }),
@@ -275,7 +279,8 @@ describe('MessageManager', () => {
         (isInIframeModule.isInIframe as jest.Mock).mockReturnValue(false);
 
         await expect(
-          manager.sendPaymentRequest(TEST_CONSTANTS.ADDRESS, {
+          manager.sendPaymentRequest({
+            addressOrEns: TEST_CONSTANTS.ADDRESS,
             amount: 100,
             currency: FiatCurrency.USD,
           }),
@@ -315,14 +320,12 @@ describe('MessageManager', () => {
         });
 
         // Create a promise to resolve when the message event is triggered
-        const paymentPromise = manager.sendPaymentRequest(
-          TEST_CONSTANTS.ADDRESS,
-          {
-            amount: 100,
-            currency: FiatCurrency.USD,
-            memo: TEST_CONSTANTS.MEMO,
-          },
-        );
+        const paymentPromise = manager.sendPaymentRequest({
+          addressOrEns: TEST_CONSTANTS.ADDRESS,
+          amount: 100,
+          currency: FiatCurrency.USD,
+          memo: TEST_CONSTANTS.MEMO,
+        });
 
         // Verify the promise resolves with the expected data
         await expect(paymentPromise).resolves.toEqual({
@@ -353,13 +356,11 @@ describe('MessageManager', () => {
         });
 
         // Create a promise that should reject when cancelled
-        const paymentPromise = manager.sendPaymentRequest(
-          TEST_CONSTANTS.ADDRESS,
-          {
-            amount: 100,
-            currency: FiatCurrency.USD,
-          },
-        );
+        const paymentPromise = manager.sendPaymentRequest({
+          addressOrEns: TEST_CONSTANTS.ADDRESS,
+          amount: 100,
+          currency: FiatCurrency.USD,
+        });
 
         // Verify the promise rejects with the expected error
         await expect(paymentPromise).rejects.toThrow('Payment was cancelled');
@@ -384,13 +385,11 @@ describe('MessageManager', () => {
         });
 
         // Create a promise that should reject when timed out
-        const paymentPromise = manager.sendPaymentRequest(
-          TEST_CONSTANTS.ADDRESS,
-          {
-            amount: 100,
-            currency: FiatCurrency.USD,
-          },
-        );
+        const paymentPromise = manager.sendPaymentRequest({
+          addressOrEns: TEST_CONSTANTS.ADDRESS,
+          amount: 100,
+          currency: FiatCurrency.USD,
+        });
 
         // Verify the promise rejects with the expected error
         await expect(paymentPromise).rejects.toThrow(
@@ -436,15 +435,13 @@ describe('MessageManager', () => {
         });
 
         // Start the payment request
-        const paymentPromise = manager.sendPaymentRequest(
-          TEST_CONSTANTS.ADDRESS,
-          {
-            amount: 100,
-            currency: FiatCurrency.USD,
-            memo: TEST_CONSTANTS.MEMO,
-            redirectUrl: TEST_CONSTANTS.REDIRECT_URL,
-          },
-        );
+        const paymentPromise = manager.sendPaymentRequest({
+          addressOrEns: TEST_CONSTANTS.ADDRESS,
+          amount: 100,
+          currency: FiatCurrency.USD,
+          memo: TEST_CONSTANTS.MEMO,
+          redirectUrl: TEST_CONSTANTS.REDIRECT_URL,
+        });
 
         // Verify the promise resolves with the expected data
         await expect(paymentPromise).resolves.toEqual({
@@ -487,14 +484,12 @@ describe('MessageManager', () => {
         });
 
         // Start the payment request
-        const paymentPromise = manager.sendPaymentRequest(
-          TEST_CONSTANTS.ADDRESS,
-          {
-            amount: 100,
-            currency: FiatCurrency.USD,
-            redirectUrl: TEST_CONSTANTS.REDIRECT_URL,
-          },
-        );
+        const paymentPromise = manager.sendPaymentRequest({
+          addressOrEns: TEST_CONSTANTS.ADDRESS,
+          amount: 100,
+          currency: FiatCurrency.USD,
+          redirectUrl: TEST_CONSTANTS.REDIRECT_URL,
+        });
 
         // Verify the promise rejects with the expected error
         await expect(paymentPromise).rejects.toThrow('Payment was cancelled');

--- a/src/__tests__/YappSDK.getUserContext.test.ts
+++ b/src/__tests__/YappSDK.getUserContext.test.ts
@@ -1,8 +1,8 @@
 // Import YappSDK first to have it available
 import { CommunicationManager } from '../managers/CommunicationManager';
 import { PaymentManager } from '../managers/PaymentManager';
-import { PaymentConfig, YappSDKConfig } from '../types/config';
-import { Hex } from '../types/utils';
+import { YappSDKConfig } from '../types/config';
+import { PaymentRequestData } from '../types/messagePayload';
 
 // Mock the MessageManager module
 jest.mock('./utils/TestMessageManagerAdapter');
@@ -43,13 +43,13 @@ class MockYappSDK {
     return this._communicationManager.getUserContext();
   }
 
-  public async requestPayment(address: Hex, config: PaymentConfig) {
+  public async requestPayment(paymentData: PaymentRequestData) {
     if (!this._paymentManager) {
       throw new Error(
         'SDK not initialized. Please wait for initialization to complete.',
       );
     }
-    return this._paymentManager.sendPaymentRequest(address, config);
+    return this._paymentManager.sendPaymentRequest(paymentData);
   }
 
   public close(targetOrigin: string) {

--- a/src/__tests__/utils/TestMessageManagerAdapter.ts
+++ b/src/__tests__/utils/TestMessageManagerAdapter.ts
@@ -1,7 +1,11 @@
 import { CommunicationManager } from '../../managers/CommunicationManager';
 import { PaymentManager } from '../../managers/PaymentManager';
-import { PaymentConfig, YappSDKConfig } from '../../types/config';
-import { Payment, UserContext } from '../../types/messagePayload';
+import { YappSDKConfig } from '../../types/config';
+import {
+  Payment,
+  PaymentRequestData,
+  UserContext,
+} from '../../types/messagePayload';
 import { RequestMessage } from '../../types/messages';
 import { Hex } from '../../types/utils';
 
@@ -30,11 +34,8 @@ export class MessageManager {
     return this.communicationManager.getUserContext();
   }
 
-  public sendPaymentRequest(
-    address: Hex,
-    config: PaymentConfig,
-  ): Promise<Payment> {
-    return this.paymentManager.sendPaymentRequest(address, config);
+  public sendPaymentRequest(paymentData: PaymentRequestData): Promise<Payment> {
+    return this.paymentManager.sendPaymentRequest(paymentData);
   }
 
   public sendCloseMessage(targetOrigin: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
   GetPaymentsQuery,
   Hex,
   Payment,
-  PaymentConfig,
+  PaymentRequestData,
   SiweRequestData,
   SiweResponseData,
   UserContext,
@@ -164,11 +164,10 @@ class YappSDK {
    * ```
    */
   public async requestPayment(
-    addressOrEns: string,
-    config: PaymentConfig,
+    paymentData: PaymentRequestData,
   ): Promise<Payment> {
     this.ensureInitialized();
-    return await this.paymentManager.sendPaymentRequest(addressOrEns, config);
+    return await this.paymentManager.sendPaymentRequest(paymentData);
   }
 
   /**

--- a/src/managers/PaymentManager.ts
+++ b/src/managers/PaymentManager.ts
@@ -86,12 +86,7 @@ export class PaymentManager extends CommunicationManager {
         return;
       }
 
-      const message = createRequestMessage('PAYMENT_REQUEST', {
-        addressOrEns: paymentData.addressOrEns,
-        amount: paymentData.amount,
-        currency: paymentData.currency,
-        memo: paymentData.memo,
-      });
+      const message = createRequestMessage('PAYMENT_REQUEST', paymentData);
 
       // Check if running in iframe
       if (isInIframe()) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,5 +1,3 @@
-import { FiatCurrency, FiatCurrencyString } from './currency';
-
 /**
  * Configuration options for the YappSDK
  *
@@ -17,27 +15,4 @@ export interface YappSDKConfig {
   apiUrl: string;
   /** URL of the mainnet RPC */
   mainnetRpcUrl: string;
-}
-
-/**
- * Payment request configuration
- *
- * @example
- * ```typescript
- * const payment: PaymentConfig = {
- *   amount: 99.99,
- *   currency: FiatCurrency.USD,
- *   memo: 'Premium subscription payment'
- * };
- * ```
- */
-export interface PaymentConfig {
-  /** The payment amount */
-  amount: number;
-  /** The currency code */
-  currency: FiatCurrency | FiatCurrencyString;
-  /** Optional payment memo/description */
-  memo?: string;
-  /** Payment redirect URL - Required when application runs outside of an iframe */
-  redirectUrl?: string;
 }

--- a/src/types/messagePayload.ts
+++ b/src/types/messagePayload.ts
@@ -1,3 +1,4 @@
+import { FiatCurrency, FiatCurrencyString } from './currency';
 import { Hex } from './utils';
 
 /**
@@ -56,4 +57,30 @@ export interface SiweResponseData {
   signature: string;
   message: string;
   address: string;
+}
+
+/**
+ * Payment request configuration
+ *
+ * @example
+ * ```typescript
+ * const payment: PaymentConfig = {
+ *   addressOrEns: '0x1234567890123456789012345678901234567890',
+ *   amount: 99.99,
+ *   currency: FiatCurrency.USD,
+ *   memo: 'Premium subscription payment'
+ * };
+ * ```
+ */
+export interface PaymentRequestData {
+  /** The recipient's blockchain address or ENS name */
+  addressOrEns: string | Hex;
+  /** The payment amount */
+  amount: number;
+  /** The currency code */
+  currency: FiatCurrency | FiatCurrencyString;
+  /** Optional payment memo/description */
+  memo?: string;
+  /** Payment redirect URL - Required when application runs outside of an iframe */
+  redirectUrl?: string;
 }

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,11 +1,10 @@
-import { PaymentConfig } from './config';
 import {
   Payment,
+  PaymentRequestData,
   SiweRequestData,
   SiweResponseData,
   UserContext,
 } from './messagePayload';
-import { Hex } from './utils';
 
 const MESSAGE_RESPONSE_PAYLOADS = {
   PAYMENT_SUCCESS: {} as Payment,
@@ -16,13 +15,7 @@ const MESSAGE_RESPONSE_PAYLOADS = {
 } as const;
 
 const MESSAGE_REQUEST_PAYLOADS = {
-  PAYMENT_REQUEST: {} as PaymentConfig & {
-    addressOrEns: string;
-    /**
-     * @deprecated Use addressOrEns instead
-     */
-    address?: Hex;
-  },
+  PAYMENT_REQUEST: {} as PaymentRequestData,
   USER_CONTEXT_REQUEST: undefined,
   CLOSE: undefined,
   SIWE_REQUEST: {} as SiweRequestData, // Request to sign a SIWE message
@@ -34,11 +27,11 @@ export const MESSAGE_RESPONSE_TYPE = Object.keys(
   [K in keyof typeof MESSAGE_RESPONSE_PAYLOADS]: K;
 };
 
-// export const MESSAGE_REQUEST_TYPE = Object.keys(
-//   MESSAGE_REQUEST_PAYLOADS,
-// ).reduce((acc, key) => ({ ...acc, [key]: key }), {}) as {
-//   [K in keyof typeof MESSAGE_REQUEST_PAYLOADS]: K;
-// };
+export const MESSAGE_REQUEST_TYPE = Object.keys(
+  MESSAGE_REQUEST_PAYLOADS,
+).reduce((acc, key) => ({ ...acc, [key]: key }), {}) as {
+  [K in keyof typeof MESSAGE_REQUEST_PAYLOADS]: K;
+};
 
 export type MessageResponseType = keyof typeof MESSAGE_RESPONSE_PAYLOADS;
 export type MessageRequestType = keyof typeof MESSAGE_REQUEST_PAYLOADS;


### PR DESCRIPTION
Unifies the params in payment requests as `PaymentRequestData` instead of `{ ensOrAddress, paymentConfig }`
This makes it uniform with other message request types and allows us to use it elsewhere, e.g. in dapp.

Also, uncommented and exported `MESSAGE_REQUEST_TYPE`